### PR TITLE
Updated ssl cert endpoint

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -85,7 +85,7 @@ module.exports = {
     rejectUnauthorized: true
   },
   logging: {
-    level: 'info' //trace, debug, info, warn, error, fatal
+    level: 'trace' //trace, debug, info, warn, error, fatal
   },
   /**
    * Options that are displayed to the user/admin in the Polarity integration user-interface.  Should be structured

--- a/integration.js
+++ b/integration.js
@@ -591,7 +591,7 @@ function onMessage(payload, options, cb) {
     case 'certificates':
       doDetailsLookup(
         {
-          path: '/v2/ssl-certificate/search',
+          path: '/v2/ssl-certificate/history',
           qs: { query: entity.value, field: 'subjectCommonName' }
         },
         entity,


### PR DESCRIPTION
The /history endpoint returns less data than the current /search. I'm not sure if this was the intention, here are docs for the data models:  [https://api.riskiq.net/api/sslcertificates/#!/default/get_pt_v2_ssl_certificate_search](url)

The data it will display using the /history endpoint: 
![Screen Shot 2022-06-22 at 2 43 59 PM](https://user-images.githubusercontent.com/84345769/175144101-18879496-5331-45b3-96e2-759b18dd70c7.png)

Entities: 
74.125.226.233 


